### PR TITLE
feat: refactors and renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Knock API access for applications written in Java.
 
 ## Documentation
 
-
 ## Installation
 
 Add the dependency to your `build.grandle` file as follows:
@@ -37,7 +36,6 @@ To use the library you must provide a secret API key, provided in the Knock dash
 You can use the KnockClientBuilder to create a KnockClient that will pull from
 environment variables.
 
-
 ```java
 KnockClient client = KnockClient.builder().build();
 ```
@@ -47,7 +45,6 @@ You can set it as an environment variable:
 ```bash
 KNOCK_API_KEY="sk_12345"
 ```
-
 
 You can also set the base API URL and API Key directly.
 
@@ -104,7 +101,7 @@ WorkflowTriggerResult result = client.workflows().trigger(workflowTrigger);
 # Set preference set for user
 PreferenceSetRequest request = PreferenceSetRequest.builder()
     .channelTypes(
-        new UserPreferenceBuilder()
+        new PreferenceSetBuilder()
             .email(true)
             .buildChannelTypes())
     .build();
@@ -115,7 +112,7 @@ client.users().setPreferences("jhammond", request);
 # Set granular workflow preferences
 PreferenceSetRequest request = PreferenceSetRequest.builder()
     .workflow("dinosaurs-loose",
-        new UserPreferenceBuilder()
+        new PreferenceSetBuilder()
             .email(false)
             .sms(true)
             .condition("recipient.handles_dino_types", "contains", "data.dino_type")
@@ -135,7 +132,7 @@ PreferenceSet defaultPreferences = client.users().getPreferencesById("jhammond",
 
 ```java
 # Set channel data for an APNS
-String channelId = "114a928a-5b35-4e1b-9069-ac873ee972d3";        
+String channelId = "114a928a-5b35-4e1b-9069-ac873ee972d3";
 ChannelData channelData = client.users().setChannelData("jhammond", channelId, Map.of("tokens", List.of("some-token")));
 
 # Get channel data for the APNS channel
@@ -163,8 +160,9 @@ client.workflows().cancel(workflowTrigger);
 ```
 
 ### Handling Exceptions
+
 Calls to resource methods will either succeed, or throw a KnockResourceException. A KnockResourceException
-is returned if a response was received with a payload from Knock that is well defined.  This is captured in the 
+is returned if a response was received with a payload from Knock that is well defined. This is captured in the
 exception, and can be used to determine the cause of the exception.
 
 See the following example code from UsersResourceTestsIT.getUser()
@@ -182,6 +180,3 @@ try {
 ```
 
 If the resource returns an Optional, KnockResourceExceptions are caught, and an empty Optional is returned.
-
-
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=0.1.1-SNAPSHOT
+version=0.2.0-SNAPSHOT
 repo.releases.url=https://s01.oss.sonatype.org/service/local/
 repo.snapshots.url=https://s01.oss.sonatype.org/content/repositories/snapshots/

--- a/src/main/java/app/knock/api/model/Activity.java
+++ b/src/main/java/app/knock/api/model/Activity.java
@@ -15,7 +15,7 @@ import java.util.Map;
 @Jacksonized
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class KnockMessageActivity {
+public class Activity {
 
     @JsonProperty("__typename")
     String typeName;
@@ -24,7 +24,7 @@ public class KnockMessageActivity {
     String cursor;
 
     String id;
-    UserIdentity actor;
+    Object actor;
     Object recipient;
     ZonedDateTime insertedAt;
     ZonedDateTime updatedAt;

--- a/src/main/java/app/knock/api/model/FeedItem.java
+++ b/src/main/java/app/knock/api/model/FeedItem.java
@@ -33,7 +33,7 @@ public class FeedItem {
     ZonedDateTime archivedAt;
 
     WorkflowSource workflowSource;
-    List<KnockMessageActivity> activities;
+    List<Activity> activities;
     List<Map<String, Object>> actors;
     Map<String, Object> data;
     List<Map<String, Object>> blocks;

--- a/src/main/java/app/knock/api/model/PreferenceSetBuilder.java
+++ b/src/main/java/app/knock/api/model/PreferenceSetBuilder.java
@@ -8,38 +8,38 @@ import java.util.List;
 import java.util.Map;
 
 
-public class UserPreferenceBuilder {
+public class PreferenceSetBuilder {
 
 
     private Map<String, Object> channelTypes = new HashMap<>();
     private List<Map<String, String>> conditions = new LinkedList<>();
 
-    public UserPreferenceBuilder email(boolean enabled) {
+    public PreferenceSetBuilder email(boolean enabled) {
         return custom("email", enabled);
     }
 
-    public UserPreferenceBuilder sms(boolean enabled) {
+    public PreferenceSetBuilder sms(boolean enabled) {
         return custom("sms", enabled);
     }
 
-    public UserPreferenceBuilder inAppFeed(boolean enabled) {
+    public PreferenceSetBuilder inAppFeed(boolean enabled) {
         return custom("in_app_feed", enabled);
     }
 
-    public UserPreferenceBuilder chat(boolean enabled) {
+    public PreferenceSetBuilder chat(boolean enabled) {
         return custom("chat", enabled);
     }
 
-    public UserPreferenceBuilder push(boolean enabled) {
+    public PreferenceSetBuilder push(boolean enabled) {
         return custom("push", enabled);
     }
 
-    public UserPreferenceBuilder custom(String key, boolean enabled) {
+    public PreferenceSetBuilder custom(String key, boolean enabled) {
         channelTypes.put(key, enabled);
         return this;
     }
 
-    public UserPreferenceBuilder condition(String variable, String operator, String argument) {
+    public PreferenceSetBuilder condition(String variable, String operator, String argument) {
         conditions.add(Map.of("variable", variable, "operator", operator, "argument", argument));
         return this;
     }

--- a/src/main/java/app/knock/api/resources/MessagesResource.java
+++ b/src/main/java/app/knock/api/resources/MessagesResource.java
@@ -115,12 +115,12 @@ public class MessagesResource {
      * @return a cursor result of message events
      * @throws KnockClientResourceException
      */
-    public CursorResult<KnockMessageActivity> activities(String messageId, QueryParams queryParams) {
+    public CursorResult<Activity> activities(String messageId, QueryParams queryParams) {
         HttpUrl url = buildChildResource(messageId, "activities", queryParams);
         Request request = knockHttp.baseJsonRequest(url)
                 .get()
                 .build();
-        return knockHttp.executeWithResponseType(request, new TypeReference<CursorResult<KnockMessageActivity>>() {
+        return knockHttp.executeWithResponseType(request, new TypeReference<CursorResult<Activity>>() {
         });
     }
 

--- a/src/main/java/app/knock/api/resources/ObjectsResource.java
+++ b/src/main/java/app/knock/api/resources/ObjectsResource.java
@@ -232,7 +232,7 @@ public class ObjectsResource {
      * @param objects
      * @return a bulk operation
      */
-    public BulkOperation bulkSetObjectsInCollection(String collection, List<Map<String, Object>> objects) {
+    public BulkOperation bulkSetInCollection(String collection, List<Map<String, Object>> objects) {
         objects.stream()
                 .filter(object -> object.get("id") != null)
                 .findAny()
@@ -254,7 +254,7 @@ public class ObjectsResource {
      * @param object_ids
      * @return a bulk operation
      */
-    public BulkOperation bulkDeleteObjectsInCollection(String collection, List<String> object_ids) {
+    public BulkOperation bulkDeleteInCollection(String collection, List<String> object_ids) {
         HttpUrl url = objectBulkSetUrl(collection, "delete");
         Request request = knockHttp.baseJsonRequest(url)
                 .post(knockHttp.objectToJsonRequestBody(Collections.singletonMap("object_ids", object_ids)))

--- a/src/main/java/app/knock/api/resources/UsersResource.java
+++ b/src/main/java/app/knock/api/resources/UsersResource.java
@@ -213,7 +213,7 @@ public class UsersResource {
      * @return channel data
      * @throws KnockClientResourceException
      */
-    public ChannelData getUserChannelData(String userId, String channelId) {
+    public ChannelData getChannelData(String userId, String channelId) {
         HttpUrl url = userChannelUrl(userId, channelId);
         Request request = knockHttp.baseJsonRequest(url)
                 .get()
@@ -229,7 +229,7 @@ public class UsersResource {
      * @param channelId
      * @throws KnockClientResourceException
      */
-    public void unsetUserChannelData(String userId, String channelId) {
+    public void unsetChannelData(String userId, String channelId) {
         HttpUrl url = userChannelUrl(userId, channelId);
         Request request = knockHttp.baseJsonRequest(url)
                 .delete()

--- a/src/test/java/app/knock/api/resources/MessagesResourceTestsIT.java
+++ b/src/test/java/app/knock/api/resources/MessagesResourceTestsIT.java
@@ -127,7 +127,7 @@ public class MessagesResourceTestsIT {
 
         KnockMessage knockMessage = getOneMessage();
 
-        CursorResult<KnockMessageActivity> activitiesResult = client.messages().activities(knockMessage.getId(), queryParams);
+        CursorResult<Activity> activitiesResult = client.messages().activities(knockMessage.getId(), queryParams);
         assertNotNull(activitiesResult);
         assertTrue(activitiesResult.getItems().size() > 0);
     }

--- a/src/test/java/app/knock/api/resources/UsersResourceTestsIT.java
+++ b/src/test/java/app/knock/api/resources/UsersResourceTestsIT.java
@@ -141,19 +141,19 @@ public class UsersResourceTestsIT {
                 .email("test_user_preferences@gmail.com")
                 .build());
 
-        Map<String, Object> workflowPreferences = new UserPreferenceBuilder()
+        Map<String, Object> workflowPreferences = new PreferenceSetBuilder()
                 .email(false)
                 .sms(true)
                 .condition("recipient.other_ids", "not_contains", "data.other_id")
                 .build();
 
-        Map<String, Object> otherCategoryPreferences = new UserPreferenceBuilder()
+        Map<String, Object> otherCategoryPreferences = new PreferenceSetBuilder()
                 .condition("recipient.muted_alert_ids", "not_contains", "data.alert_id")
                 .condition("recipient.other_ids", "not_contains", "data.other_id")
                 .build();
 
         PreferenceSetRequest request = PreferenceSetRequest.builder()
-                .channelTypes(new UserPreferenceBuilder()
+                .channelTypes(new PreferenceSetBuilder()
                         .email(true)
                         .buildChannelTypes())
                 .workflow("new-feature", workflowPreferences)

--- a/src/test/java/app/knock/api/resources/UsersResourceTestsIT.java
+++ b/src/test/java/app/knock/api/resources/UsersResourceTestsIT.java
@@ -93,7 +93,7 @@ public class UsersResourceTestsIT {
     }
 
     @Test
-    void userChannelDataManipulation() {
+    void channelDataManipulation() {
         UserIdentity userIdentity = client.users().identify("test_get_user", UserIdentity.builder()
                 .name("User name")
                 .email("test_get_user@gmail.com")
@@ -104,20 +104,20 @@ public class UsersResourceTestsIT {
         String userId = userIdentity.getId();
         String channelId = "7341aee6-3956-4977-b0f4-032ac1e74336";
 
-        client.users().unsetUserChannelData(userId, channelId);
+        client.users().unsetChannelData(userId, channelId);
 
         Assertions.assertThrows(KnockClientResourceException.class, () -> {
-            client.users().getUserChannelData(userId, channelId);
+            client.users().getChannelData(userId, channelId);
         });
 
         ChannelData data = client.users().setChannelData(userId, channelId, Map.of("tokens", List.of("some-token")));
-        ChannelData newData = client.users().getUserChannelData(userId, channelId);
+        ChannelData newData = client.users().getChannelData(userId, channelId);
 
         assertEquals(data, newData);
         assertEquals("some-token", ((List<String>) data.getData().get("tokens")).get(0));
         assertEquals("some-token", ((List<String>) newData.getData().get("tokens")).get(0));
 
-        client.users().unsetUserChannelData(userId, channelId);
+        client.users().unsetChannelData(userId, channelId);
         client.users().delete(userId);
     }
 


### PR DESCRIPTION
* Users: changed `setUserChannelData` and `unsetUserChannelData` to not have `User` prefix
* Renamed `KnockMessageActivity` to `Activity` given this exists outside of a message
* Renamed `UserPreferenceBuilder` to `PreferenceSetBuilder` so we can reuse in objects
* Renamed `bulkSetObjectsInCollection` to `bulkSetInCollection` (removed `Objects` prefix)