### PR TITLE
feat(kno-3769): add subscriptions support

### DIFF
--- a/src/main/java/app/knock/api/model/AddSubscriptionsRequest.java
+++ b/src/main/java/app/knock/api/model/AddSubscriptionsRequest.java
@@ -1,0 +1,72 @@
+package app.knock.api.model;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Value
+@Jacksonized
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AddSubscriptionsRequest {
+
+    @JsonProperty("__typename")
+    String typeName;
+
+    List<Object> recipients;
+
+    @Singular("properties")
+    @JsonAnySetter
+    Map<String, Object> properties;
+
+    public <T> T properties(String key, Class<T> clazz) {
+        if (this.properties != null && this.properties.containsKey(key)) {
+            Object o = this.properties.get(key);
+            return clazz.isInstance(o) ? clazz.cast(o) : null;
+        }
+        return null;
+    }
+
+    public static class AddSubscriptionsRequestBuilder {
+
+        List<Object> recipients;
+
+        public AddSubscriptionsRequestBuilder addRecipient(String... userIds) {
+            if (this.recipients == null) { this.recipients = new ArrayList<>(); }
+            Collections.addAll(this.recipients, userIds);
+            return this;
+        }
+
+        public AddSubscriptionsRequestBuilder addRecipient(Map<String, Object> recipient) {
+            if (this.recipients == null) { this.recipients = new ArrayList<>(); }
+            Collections.addAll(this.recipients, recipient);
+            return this;
+        }
+
+        public AddSubscriptionsRequestBuilder addRecipient(ObjectRecipientIdentifier identifier) {
+            if (this.recipients == null) { this.recipients = new ArrayList<>(); }
+            Collections.addAll(this.recipients, identifier);
+            return this;
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class ObjectRecipientIdentifier {
+
+        String id;
+        String collection;
+
+    }
+
+}

--- a/src/main/java/app/knock/api/model/DeleteSubscriptionsRequest.java
+++ b/src/main/java/app/knock/api/model/DeleteSubscriptionsRequest.java
@@ -1,0 +1,58 @@
+package app.knock.api.model;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Value
+@Jacksonized
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DeleteSubscriptionsRequest {
+
+    @JsonProperty("__typename")
+    String typeName;
+
+    List<Object> recipients;
+
+    public static class DeleteSubscriptionsRequestBuilder {
+
+        List<Object> recipients;
+
+        public DeleteSubscriptionsRequestBuilder addRecipient(String... userIds) {
+            if (this.recipients == null) { this.recipients = new ArrayList<>(); }
+            Collections.addAll(this.recipients, userIds);
+            return this;
+        }
+
+        public DeleteSubscriptionsRequestBuilder addRecipient(Map<String, Object> recipient) {
+            if (this.recipients == null) { this.recipients = new ArrayList<>(); }
+            Collections.addAll(this.recipients, recipient);
+            return this;
+        }
+
+        public DeleteSubscriptionsRequestBuilder addRecipient(ObjectRecipientIdentifier identifier) {
+            if (this.recipients == null) { this.recipients = new ArrayList<>(); }
+            Collections.addAll(this.recipients, identifier);
+            return this;
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class ObjectRecipientIdentifier {
+
+        String id;
+        String collection;
+    }
+}

--- a/src/main/java/app/knock/api/model/ObjectSubscription.java
+++ b/src/main/java/app/knock/api/model/ObjectSubscription.java
@@ -1,0 +1,40 @@
+package app.knock.api.model;
+
+import com.fasterxml.jackson.annotation.*;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@Value
+@Jacksonized
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ObjectSubscription {
+    @JsonProperty("__typename")
+    String typeName;
+
+    @JsonProperty("__cursor")
+    String cursor;
+
+    Object recipient;
+    Object object;
+    ZonedDateTime insertedAt;
+    ZonedDateTime updatedAt;
+
+    @Singular("properties")
+    @JsonAnySetter
+    @JsonSetter(nulls = Nulls.SKIP)
+    Map<String, Object> properties;
+
+    public <T> T properties(String key, Class<T> clazz) {
+        if (this.properties != null && this.properties.containsKey(key)) {
+            Object o = this.properties.get(key);
+            return clazz.isInstance(o) ? clazz.cast(o) : null;
+        }
+        return null;
+    }
+}

--- a/src/main/java/app/knock/api/resources/ObjectsResource.java
+++ b/src/main/java/app/knock/api/resources/ObjectsResource.java
@@ -252,7 +252,7 @@ public class ObjectsResource {
     }
 
     /**
-     * Retrieve a CursorResult of Schedules for a specific KnockObject as recipient.
+     * Retrieve a CursorResult of ObjectSubscriptions for a specific KnockObject as recipient.
      *
      * @param collection
      * @param objectId

--- a/src/main/java/app/knock/api/resources/ObjectsResource.java
+++ b/src/main/java/app/knock/api/resources/ObjectsResource.java
@@ -21,6 +21,12 @@ public class ObjectsResource {
 
     KnockHttp knockHttp;
 
+    HttpUrl buildListResource(String objectId, ObjectsResource.ObjectsParams queryParams) {
+        HttpUrl.Builder urlBuilder = knockHttp.baseUrlBuilder(BASE_RESOURCE_PATH, objectId);
+        queryParams.addQueryParams(urlBuilder);
+        return urlBuilder.build();
+    }
+
     HttpUrl objectUrl(String collection, String objectId) {
         return knockHttp.baseUrlBuilder(BASE_RESOURCE_PATH, collection, objectId).build();
     }
@@ -78,6 +84,23 @@ public class ObjectsResource {
                 .get()
                 .build();
         return knockHttp.executeWithResponseType(request, new TypeReference<KnockObject>() {
+        });
+    }
+
+    /**
+     * Retrieve paginated list of KnockObject
+     *
+     * @param collection
+     * @param queryParams
+     * @throws KnockClientResourceException Unable able to retrieve KnockObject from the resource
+     * @return KnockObject
+     */
+    public CursorResult<KnockObject> list(String collection, ObjectsParams queryParams) {
+        HttpUrl url = buildListResource(collection, queryParams);
+        Request request = knockHttp.baseJsonRequest(url)
+                .get()
+                .build();
+        return knockHttp.executeWithResponseType(request, new TypeReference<CursorResult<KnockObject>>() {
         });
     }
 
@@ -288,4 +311,28 @@ public class ObjectsResource {
         });
     }
 
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    public static class ObjectsParams {
+        private final Map<String, Object> params = new HashMap<>();
+
+        public void pageSize(Integer pageSize) {
+            params.put("page_size", pageSize);
+        }
+
+        public void after(String after) {
+            params.put("after", after);
+        }
+
+        public void before(String before) {
+            params.put("before", before);
+        }
+
+        public void addQueryParams(HttpUrl.Builder uriBuilder) {
+            params.entrySet()
+                    .stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(entry -> uriBuilder.addQueryParameter(entry.getKey(), entry.getValue().toString()));
+        }
+    }
 }

--- a/src/main/java/app/knock/api/resources/UsersResource.java
+++ b/src/main/java/app/knock/api/resources/UsersResource.java
@@ -21,6 +21,11 @@ public class UsersResource {
 
     KnockHttp knockHttp;
 
+    HttpUrl buildListResource(UsersParams queryParams) {
+        HttpUrl.Builder urlBuilder = knockHttp.baseUrlBuilder(BASE_RESOURCE_PATH);
+        queryParams.addQueryParams(urlBuilder);
+        return urlBuilder.build();
+    }
     HttpUrl userUrl(String userId) {
         return knockHttp.baseUrlBuilder(BASE_RESOURCE_PATH, userId).build();
     }
@@ -131,6 +136,22 @@ public class UsersResource {
                 .get()
                 .build();
         return knockHttp.executeWithResponseType(request, new TypeReference<UserIdentity>() {
+        });
+    }
+
+    /**
+     * Retrieve users from knock
+     *
+     * @param queryParams
+     * @return a cursor result of users
+     * @throws KnockClientResourceException
+     */
+    public CursorResult<UserIdentity> list(UsersParams queryParams) {
+        HttpUrl url = buildListResource(queryParams);
+        Request request = knockHttp.baseJsonRequest(url)
+                .get()
+                .build();
+        return knockHttp.executeWithResponseType(request, new TypeReference<CursorResult<UserIdentity>>() {
         });
     }
 
@@ -411,5 +432,28 @@ public class UsersResource {
                     .forEach(entry -> uriBuilder.addQueryParameter(entry.getKey(), entry.getValue().toString()));
         }
     }
+    @Value
+    @EqualsAndHashCode(callSuper = false)
+    public static class UsersParams {
+        private final Map<String, Object> params = new HashMap<>();
 
+        public void pageSize(Integer pageSize) {
+            params.put("page_size", pageSize);
+        }
+
+        public void after(String after) {
+            params.put("after", after);
+        }
+
+        public void before(String before) {
+            params.put("before", before);
+        }
+
+        public void addQueryParams(HttpUrl.Builder uriBuilder) {
+            params.entrySet()
+                    .stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(entry -> uriBuilder.addQueryParameter(entry.getKey(), entry.getValue().toString()));
+        }
+    }
 }

--- a/src/main/java/app/knock/api/resources/UsersResource.java
+++ b/src/main/java/app/knock/api/resources/UsersResource.java
@@ -63,6 +63,14 @@ public class UsersResource {
         return urlBuilder.build();
     }
 
+    HttpUrl userSubscriptionsUrl(String userId, ObjectsResource.ListParams queryParams) {
+        HttpUrl.Builder urlBuilder = userUrl(userId)
+                .newBuilder()
+                .addEncodedPathSegment("subscriptions");
+        queryParams.addQueryParams(urlBuilder);
+        return urlBuilder.build();
+    }
+
     HttpUrl userFeedUrl(String userId, String feedId, FeedQueryParams feedQueryParams) {
         HttpUrl.Builder urlBuilder = knockHttp.baseUrlBuilder(BASE_RESOURCE_PATH, userId, "feeds", feedId);
         feedQueryParams.addQueryParams(urlBuilder);
@@ -223,7 +231,7 @@ public class UsersResource {
      *
      * @param userId
      * @param queryParams
-     * @return
+     * @return a cursor result of messages
      */
     public CursorResult<KnockMessage> getMessages(String userId, MessagesResource.QueryParams queryParams) {
         HttpUrl url = userMessagesUrl(userId, queryParams);
@@ -239,7 +247,7 @@ public class UsersResource {
      *
      * @param userId
      * @param queryParams
-     * @return
+     * @return a cursor result of schedules
      */
     public CursorResult<Schedule> getSchedules(String userId, WorkflowsResource.SchedulesQueryParams queryParams) {
         HttpUrl url = userSchedulesUrl(userId, queryParams);
@@ -250,6 +258,21 @@ public class UsersResource {
         });
     }
 
+    /**
+     * Retrieve a CursorResult of object subscriptions for a specific User.
+     *
+     * @param userId
+     * @param queryParams
+     * @return a cursor result of object subscriptions
+     */
+    public CursorResult<ObjectSubscription> getSubscriptions(String userId, ObjectsResource.ListParams queryParams) {
+        HttpUrl url = userSubscriptionsUrl(userId, queryParams);
+        Request request = knockHttp.baseJsonRequest(url)
+                .get()
+                .build();
+        return knockHttp.executeWithResponseType(request, new TypeReference<CursorResult<ObjectSubscription>>() {
+        });
+    }
 
     /**
      * Retrieve a user's ChannelData for a particular channelId.


### PR DESCRIPTION
Adds support for subscription endpoints:
* Add subscriptions to objects
* Delete subscriptions
* List subscription for object
* Get subscriptions for object as recipient
* Get subscriptions for user

Also adds missing support for:
* List users for environment
* List objects by collection for environment